### PR TITLE
Lifetime Stats and Discord Member tables to DB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv==1.0.0
 aiohttp==3.8.4
 SQLAlchemy==2.0.20
 aiosqlite==0.17.0
+mysql-connector-python==9.4.0 #probably need this for SQLAlchemy, putting this here just in case
 
 #Testing (I just put whatever I found relevant and whats on the doc - Rishi)
 pytest==7.4.0

--- a/src/db_skeleton.py
+++ b/src/db_skeleton.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, Date
+from sqlalchemy import Column, Integer, String, ForeignKey, Date, UniqueConstraint
 from sqlalchemy.orm import declarative_base, relationship
 
 #Base class for SQLAlchemy
@@ -6,6 +6,7 @@ from sqlalchemy.orm import declarative_base, relationship
 #but be nice about it please
 Base = declarative_base()
 
+### ------------------------------------------------------------ FOOTBALL DATA ------------------------------------------------------------------------------------
 class Team(Base):
     __tablename__ = "teams"
     id = Column(Integer, primary_key=True)  #APIs we are pulling from presumably have each team mapped to a unique ID. 
@@ -19,6 +20,7 @@ class Team(Base):
     #home-away classification is not as important but in some leagues it makes a difference. easily editable 
     #if we decide to do so though.
     away_matches = relationship("Match", foreign_keys='Match.away_team_id', back_populates="away_team") 
+    subscriptions = relationship("TeamSubscription", back_populates="team") #Discord members who follow this team
 
 class Player(Base):
     __tablename__ = "players"
@@ -29,13 +31,9 @@ class Player(Base):
     age = Column(Integer)
     nationality = Column(String(50))
     team = relationship("Team", back_populates="players")
-    stats = relationship("PlayerStat", back_populates="player") 
-
-#My thinking is that since we're doing live updates each Player gets assigned a PlayerStat object for each match, so it's 
-#One to Many here, instead of tracking lifetime stats. If we do lifetime stats they would go here in this table and be 
-#updated as PlayerStat objects are updated. That would require just a little more finagling which 
-#I can take a look at later. What we then need to think of is how we are IDing PlayerStat objects--- 
-#something to consider when API wrangling.
+    stats = relationship("PlayerStat", back_populates="player")
+    lifetime_stats = relationship("LifetimeStat", uselist=False, back_populates="player")  # One-to-One
+    subscriptions = relationship("PlayerSubscription", back_populates="player")  # Discord members who follow this player
 
 class Match(Base):
     __tablename__ = "matches"
@@ -61,3 +59,73 @@ class PlayerStat(Base):
     minutes_played = Column(Integer, default=0)
     player = relationship("Player", back_populates="stats")
     match = relationship("Match", back_populates="stats") #yapped enough on the other ones that hopefully this object is clear. 
+    lifetime_stats = relationship("LifetimeStat", uselist=False, back_populates="player", cascade="all, delete-orphan") #use-list ensures the relation is one to one i believe
+    #creates a lifetimestat object that hopefully is always pointed to by one player. bidirectional because it's more convenient to have
+    #everything point to playerstat over going to lifetime stat separately. 
+
+
+class LifetimeStat(Base):
+    __tablename__ = "lifetime_stats"
+
+    id = Column(Integer, primary_key=True)
+    player_id = Column(Integer, ForeignKey('players.id'), unique=True, nullable=False)
+    total_goals = Column(Integer, default=0)
+    total_assists = Column(Integer, default=0)
+    total_yellow_cards = Column(Integer, default=0)
+    total_red_cards = Column(Integer, default=0)
+    total_minutes_played = Column(Integer, default=0)
+    appearances = Column(Integer, default=0)
+    player = relationship("Player", back_populates="lifetime_stats")
+    #the way this object is set-up we can either handle aggregation ourselves or do API calls on this. One
+    #is faster than the other but is also a lot easier to mess up haha
+
+#THINGS TO CONSIDER: How are our API calls going to be handled for these objects?
+
+### ------------------------------------------------------------ DISCORD TRACKING ------------------------------------------------------------------------------------
+#not the right amount of hyphens surely. it's fine we'll live. 
+
+class Member(Base):
+    __tablename__ = "members"
+    id = Column(Integer, primary_key=True) #our internal primary key. if we want to finagle this into being the discord_id we can do that too i think
+    discord_id = Column(String(50), unique=True, nullable=False) #discord key 
+    username = Column(String(100))
+    timezone = Column(String(50)) #transforms on the date-time for matches 
+    player_subscriptions = relationship("PlayerSubscription", back_populates="member")
+    team_subscriptions = relationship("TeamSubscription", back_populates="member") #storing these separately because it gets messy
+    #haha messi
+    #otherwise
+
+class PlayerSubscription(Base):
+    __tablename__ = "player_subscriptions"
+    id = Column(Integer, primary_key=True)
+    member_id = Column(Integer, ForeignKey('members.id'))
+    player_id = Column(Integer, ForeignKey('players.id'))
+    notify_on_goal = Column(Integer, default=1)
+    notify_on_card = Column(Integer, default=1)
+    notify_on_match = Column(Integer, default=0) #things that i think are worth having the subscribe call for
+    #could extend into fouls etc (but we said we don't want to do haterisms haha)
+    member = relationship("Member", back_populates="player_subscriptions")
+    player = relationship("Player", back_populates="subscriptions")
+    __table_args__ = (UniqueConstraint('member_id', 'player_id', name='_member_player_uc'),) #no duplicate subs 
+    #also idk if naming convention is _name for the name field here or if you have to do that but 
+    #every example i've found does it like this. so i guess we'll be a goody two shoes about it. 
+
+
+class TeamSubscription(Base):
+    __tablename__ = "team_subscriptions"
+    id = Column(Integer, primary_key=True)
+    member_id = Column(Integer, ForeignKey('members.id'))
+    team_id = Column(Integer, ForeignKey('teams.id'))
+    notify_on_goal = Column(Integer, default=0)
+    notify_on_match = Column(Integer, default=1)
+    #don't think we can track team getting carded unless we are looking at 
+    #players and then mapping that to teams and then mapping that back here
+    #APIs don't seem to offer aggregate team card trackers I think. Either way, maybe a stretch feature? 
+    member = relationship("Member", back_populates="team_subscriptions")
+    team = relationship("Team", back_populates="subscriptions")
+    __table_args__ = (UniqueConstraint('member_id', 'team_id', name='_member_team_uc'),) #no duplicate subs
+
+
+
+
+


### PR DESCRIPTION
Database now includes a Lifetime Stats object as discussed + Rudimentary tables to manage members and their subscriptions to Players and Teams. Minor tweak to requirements.txt to pre-emptively include mysql-connector, just in case.